### PR TITLE
Remove beta from page title

### DIFF
--- a/public/views/index.html
+++ b/public/views/index.html
@@ -8,7 +8,7 @@
 <head>
   <base href="/" />
   <meta charset="utf-8">
-  <title>askaway (beta) | Myplanet</title>
+  <title>Askaway | Myplanet</title>
 
   <meta name="viewport" content="width=device-width, user-scalable=no,initial-scale=1, maximum-scale=1, minimum-scale=1"/>
 


### PR DESCRIPTION
Resolves #3 

This PR is a small change adjusting the title to the page title to remove the beta text.